### PR TITLE
chore: refine plugin categories + sync smart-cut-monologue version

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -27,7 +27,7 @@
         "price-comparison",
         "bilingual"
       ],
-      "category": "productivity"
+      "category": "travel"
     },
     {
       "name": "mac-doctor",
@@ -50,7 +50,7 @@
         "maintenance",
         "diagnostics"
       ],
-      "category": "productivity"
+      "category": "system"
     },
     {
       "name": "bilingual-video-sub",
@@ -73,7 +73,7 @@
         "bilingual",
         "ffmpeg"
       ],
-      "category": "productivity"
+      "category": "media-tools"
     },
     {
       "name": "media-to-srt",
@@ -103,7 +103,7 @@
         "doubao",
         "speaker-diarization"
       ],
-      "category": "productivity"
+      "category": "media-tools"
     },
     {
       "name": "xiaoyuzhou-to-audio",
@@ -126,7 +126,7 @@
         "download",
         "aria2c"
       ],
-      "category": "productivity"
+      "category": "media-tools"
     },
     {
       "name": "smart-cut-monologue",
@@ -135,7 +135,7 @@
         "repo": "pierrelzw/smart-cut-monologue"
       },
       "description": "Smart-cut monologue videos on Apple Silicon — mlx-qwen3-asr transcription + 剪映-style transcript-inline review UI + frame-accurate ffmpeg cut. Removes filler / repetition / pauses with human-in-the-loop review.",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "author": {
         "name": "pierrelzw"
       },
@@ -151,7 +151,7 @@
         "macos",
         "apple-silicon"
       ],
-      "category": "productivity"
+      "category": "media-tools"
     },
     {
       "name": "issue-workflow",
@@ -175,7 +175,7 @@
         "codex",
         "review"
       ],
-      "category": "productivity"
+      "category": "developer-tools"
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -81,8 +81,8 @@
         "source": "github",
         "repo": "pierrelzw/media-to-srt"
       },
-      "description": "Transcribe a video or audio file (URL or local) into an SRT subtitle file using whisper.cpp — supports any yt-dlp-compatible platform (YouTube, Bilibili, 小红书, 抖音, Vimeo, Twitter/X, etc.) plus local audio (mp3/m4a/wav/aac/flac)",
-      "version": "0.2.0",
+      "description": "Transcribe a video or audio file (URL or local) into an SRT subtitle file. Choose: fast Douban ASR (with speaker diarization) or local whisper.cpp (private). Supports YouTube, Bilibili, 小红书, 抖音, Vimeo, Twitter/X, and local files (mp3/m4a/wav/aac/flac/mp4/webm/ogg).",
+      "version": "0.3.0",
       "author": {
         "name": "pierrelzw"
       },
@@ -97,7 +97,11 @@
         "transcription",
         "yt-dlp",
         "podcast",
-        "speech-to-text"
+        "speech-to-text",
+        "asr",
+        "douban",
+        "doubao",
+        "speaker-diarization"
       ],
       "category": "productivity"
     },


### PR DESCRIPTION
## Summary
- Replace blanket `productivity` category with semantic categories:
  - travel: search-flights
  - system: mac-doctor
  - media-tools: bilingual-video-sub, media-to-srt, xiaoyuzhou-to-audio, smart-cut-monologue
  - developer-tools: issue-workflow
- Bump `smart-cut-monologue` 0.1.0 → 0.1.1 to match plugin repo (hub was stale).

## Note
`media-to-srt` version drift remains (hub 0.3.0 vs repo 0.2.0); the repo needs an actual 0.3.0 release. Tracked separately.

## Related
All 7 plugin repos now have self-marketplace.json (xiaolai pattern) — install single plugin via `/plugin marketplace add pierrelzw/<repo>`.