### PR TITLE
chore: bump search-flights to 0.1.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
         "repo": "pierrelzw/search-flights"
       },
       "description": "Search and compare flight prices across flexible date ranges using Google Flights — bilingual Chinese/English, multi-airport support",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "author": {
         "name": "pierrelzw"
       },


### PR DESCRIPTION
Picks up pierrelzw/search-flights#6 — skill moved to standard `skills/search-flights/` layout, gets `/search-flights:search-flights` slash command.