### PR TITLE
Register zhiwei-images plugin (v0.1.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -225,6 +225,31 @@
         "ffmpeg"
       ],
       "category": "media-tools"
+    },
+    {
+      "name": "zhiwei-images",
+      "source": {
+        "source": "github",
+        "repo": "pierrelzw/zhiwei-images"
+      },
+      "description": "Generate WeChat/Xiaohongshu article covers and infographic series via the local Codex subscription (built-in image_gen / gpt-image-2, no API key)",
+      "version": "0.1.0",
+      "author": {
+        "name": "pierrelzw"
+      },
+      "repository": "https://github.com/pierrelzw/zhiwei-images",
+      "license": "MIT",
+      "keywords": [
+        "cover-image",
+        "xiaohongshu",
+        "xhs",
+        "infographic",
+        "image-generation",
+        "codex",
+        "gpt-image",
+        "wechat"
+      ],
+      "category": "productivity"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ claude plugin marketplace add pierrelzw/zhiwei_skills
 | [xiaoyuzhou-to-audio](https://github.com/pierrelzw/xiaoyuzhou-to-audio) | Download 小宇宙 podcast episodes to local .m4a via aria2c — up to 6 episodes in parallel | 0.1.0 |
 | [issue-workflow](https://github.com/pierrelzw/issue-workflow) | End-to-end GitHub issue workflow — preflight → plan (codex review) → worktree → implement → verify → review → PR → CI → merge | 0.1.0 |
 | [time-report](https://github.com/pierrelzw/time-report) | Interactive HTML Gantt + token/cost report for Claude Code & Codex sessions | 3.5.0 |
+| [zhiwei-images](https://github.com/pierrelzw/zhiwei-images) | Generate 公众号/小红书 article covers + infographic series via the local Codex subscription (built-in image_gen / gpt-image-2, no API key) | 0.1.0 |
 
 ## Installing Plugins
 


### PR DESCRIPTION
## What

Registers the new **zhiwei-images** plugin in the marketplace (`marketplace.json` + README table).

It bundles two skills:
- **zhiwei-cover-image** — article cover images (5 dimensions, 16:9 / 2.35:1 / 1:1 / 3:4)
- **zhiwei-xhs-images** — Xiaohongshu infographic series (11 styles × 8 layouts)

## Why

Forked from baoyu-skills, but the image engine is swapped to the **local Codex subscription** (Codex CLI built-in `image_gen`, gpt-image-2) — so users need **no `OPENAI_API_KEY`**. The engine is isolated to one script (`scripts/codex-imagegen.sh`); style confirmation is a blocking gate so the skill always asks the user for style before generating.

Repo: https://github.com/pierrelzw/zhiwei-images

🤖 Generated with [Claude Code](https://claude.com/claude-code)